### PR TITLE
Fix panic in timescale target with `iot` use case (#233)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@
 .vscode
 *~
 
+bin
+
 # High Dynamic Range (HDR) Histogram files
 *.hdr

--- a/pkg/targets/timescaledb/creator.go
+++ b/pkg/targets/timescaledb/creator.go
@@ -116,7 +116,6 @@ func (d *dbCreator) PostCreateDB(dbName string) error {
 				}
 				r = MustQuery(dbBench, checkTableQuery)
 			}
-			return nil
 		}
 	}
 	return nil


### PR DESCRIPTION
* Ensure all tables are created before continuing

When create-metrics-table is false, PostCreateDB does not populate tableCols, causing incorrect column count in Timescale processor.  Wait for all tables to be created.



* Ignore `out` directory



---------